### PR TITLE
removes applescript, implements pure python

### DIFF
--- a/data/BTTSchema.js
+++ b/data/BTTSchema.js
@@ -38,8 +38,8 @@ const mainStruct = function() {
 const cryptoElement = function() {
     return {
         "BTTWidgetName": "",
-        "BTTTriggerType": 639,
-        "BTTTriggerTypeDescription": "Apple Script Widget",
+        "BTTTriggerType": 642,
+        "BTTTriggerTypeDescription": "Shell Script \/ Task Widget",
         "BTTTriggerClass": "BTTTriggerTypeTouchBar",
         "BTTPredefinedActionType": -1,
         "BTTPredefinedActionName": "No Action",
@@ -47,6 +47,7 @@ const cryptoElement = function() {
         "BTTEnabled": 1,
         "BTTOrder": 0,
         "BTTIconData": "**WILL-BE-REPLACED**",
+        "BTTShellScriptWidgetGestureConfig" : "\/usr\/bin\/python:::-c",
         "BTTTriggerConfig": {
             "BTTTouchBarItemIconHeight": 22,
             "BTTTouchBarItemIconWidth": 22,
@@ -54,7 +55,7 @@ const cryptoElement = function() {
             "BTTTouchBarFreeSpaceAfterButton": "5.000000",
             "BTTTouchBarButtonColor": "243.776725, 130.266312, 8.181293, 255.000000",
             "BTTTouchBarAlwaysShowButton": "0",
-            "BTTTouchBarAppleScriptString": "set value to do shell script \"curl '**REQUEST**' | python -c **RESPONSE** **OUTPUT**",
+            "BTTTouchBarAppleScriptString": "**RESPONSE****OUTPUT**",
             "BTTTouchBarAlternateBackgroundColor": "109.650002, 109.650002, 109.650002, 255.000000",
             "BTTTouchBarScriptUpdateInterval": 60
         }

--- a/data/apiSchema.js
+++ b/data/apiSchema.js
@@ -1,20 +1,18 @@
 const APIPrice = function() {
     return {
         "live" : {
-            "request" : "https:\/\/min-api.cryptocompare.com\/data\/pricemultifull?fsyms=**CRYPTO**&tsyms=**FIAT**",
-            "response" : "'import json,sys;obj=json.load(sys.stdin);print \\\"{**FORMAT**}\\\".format(obj[\\\"RAW\\\"][\\\"**CRYPTO**\\\"][\\\"**FIAT**\\\"][\\\"PRICE\\\"]);print obj[\\\"RAW\\\"][\\\"**CRYPTO**\\\"][\\\"**FIAT**\\\"][\\\"OPEN24HOUR\\\"];print \\\"{**FORMAT**}\\\".format(obj[\\\"RAW\\\"][\\\"**CRYPTO**\\\"][\\\"**FIAT**\\\"][\\\"HIGHDAY\\\"]);print \\\"{**FORMAT**}\\\".format(obj[\\\"RAW\\\"][\\\"**CRYPTO**\\\"][\\\"**FIAT**\\\"][\\\"LOWDAY\\\"]);print obj[\\\"RAW\\\"][\\\"**CRYPTO**\\\"][\\\"**FIAT**\\\"][\\\"PRICE\\\"];print obj[\\\"RAW\\\"][\\\"**CRYPTO**\\\"][\\\"**FIAT**\\\"][\\\"HIGHDAY\\\"];print obj[\\\"RAW\\\"][\\\"**CRYPTO**\\\"][\\\"**FIAT**\\\"][\\\"LOWDAY\\\"];'\"\rset valueArray to words of value\rset trend to \"null\"\rset current to item 1 of valueArray\rset opening to (item 2 of valueArray as integer)\rset high to item 3 of valueArray\rset low to item 4 of valueArray\rset raw_current to (item 5 of valueArray as integer)\rset raw_high to (item 6 of valueArray as integer)\rset raw_low to (item 7 of valueArray as integer)",
-            "no-output" : "\rreturn \"**FIATSYMB**\" & current",
-            "simple-output" : "\rif raw_current > opening then\r\tset trend to \"▲\"\relse\r\tset trend to \"▼\"\rend if\r\rreturn \"**FIATSYMB**\" & current & \" \" & trend",
-            "absolute-output" : "\rreturn \"**FIATSYMB**\" & current & \" (L: **FIATSYMB**\" & low & \" H: **FIATSYMB**\" & high & \")\"",
-            "relative-output" : "\rreturn \"**FIATSYMB**\" & current & \" (L: -**FIATSYMB**\" & (raw_current - raw_low) & \" H: +**FIATSYMB**\" & (raw_high - raw_current) & \")\"",
-            "current-percentage-output" : "\rreturn \"**FIATSYMB**\" & current & \" (\" & (round(((raw_current - opening) / raw_current)*100)) & \"%)\"",
-            "range-percentage-output" : "\rreturn \"**FIATSYMB**\" & current & \" (L: -\" & (round(((raw_current - raw_low) / raw_current)*100)) & \"% H: +\" & (round(((raw_high - raw_current) / raw_current)*100)) & \"%)\"",
-            "user-percentage-output" : "\rreturn \"**FIATSYMB**\" & current & \" (L: **FIATSYMB**\" & ((raw_current - (raw_current* **PERCENT**)) as integer) & \" H: **FIATSYMB**\" & ((raw_current + (raw_current* **PERCENT**)) as integer) & \")\""
+            "response" : "import urllib2,json,sys\n\ndata = urllib2.urlopen(\"https:\/\/min-api.cryptocompare.com\/data\/pricemultifull?fsyms=**CRYPTO**&tsyms=**FIAT**\")\nobj=json.load(data)\ncurrent = \"{**FORMAT**}\".format(obj[\"RAW\"][\"**CRYPTO**\"][\"**FIAT**\"][\"PRICE\"])\nopening = obj[\"RAW\"][\"**CRYPTO**\"][\"**FIAT**\"][\"OPEN24HOUR\"]\nhigh = \"{**FORMAT**}\".format(obj[\"RAW\"][\"**CRYPTO**\"][\"**FIAT**\"][\"HIGHDAY\"])\nlow = \"{**FORMAT**}\".format(obj[\"RAW\"][\"**CRYPTO**\"][\"**FIAT**\"][\"LOWDAY\"])\nraw_current = obj[\"RAW\"][\"**CRYPTO**\"][\"**FIAT**\"][\"PRICE\"]\nraw_high = obj[\"RAW\"][\"**CRYPTO**\"][\"**FIAT**\"][\"HIGHDAY\"]\nraw_low = obj[\"RAW\"][\"**CRYPTO**\"][\"**FIAT**\"][\"LOWDAY\"]\n\n",
+            "no-output" : "print(\"**FIATSYMB**\" + current)",
+            "simple-output" : "if (raw_current > opening):\n\ttrend = \"▲\"\nelse:\n\ttrend = \"▼\"\n\nprint(\"**FIATSYMB**\" + current + \" \" + trend)",
+            "absolute-output" : "print (\"**FIATSYMB**\" + current + \" (L: **FIATSYMB**\" + low + \" H: **FIATSYMB**\" + high + \")\")",
+            "relative-output" : "print(\"**FIATSYMB**\" + current + \" (L: -**FIATSYMB**\" + str(raw_current - raw_low) + \" H: +**FIATSYMB**\" + str(raw_high - raw_current) + \")\")",
+            "current-percentage-output" : "print (\"**FIATSYMB**\" + current + \" (\" + str(round (((raw_current - opening) \/ raw_current) * 100)) + \"%)\")",
+            "range-percentage-output" : "print(\"**FIATSYMB**\" + current + \" (L: -\" + str(round (((raw_current - raw_low) \/ raw_current) * 100)) + \"% H: +\" + str(round (((raw_high - raw_current) \/ raw_current) * 100)) + \"%)\")",
+            "user-percentage-output" : "print(\"**FIATSYMB**\" + current + \" (L: **FIATSYMB**\" + str(raw_current - (raw_current * **PERCENT**)) + \" H: **FIATSYMB**\" + str(raw_current + (raw_current * **PERCENT**)) + \")\")"
         },
         "historical" : {
-            "request" : "https:\/\/min-api.cryptocompare.com\/data\/histohour?fsym=**CRYPTO**&tsym=**FIAT**&**EXTRAOPTIONS**",
-            "response" : "'import json,sys;obj=json.load(sys.stdin);print \\\"{**FORMAT**}\\\".format(obj[\\\"Data\\\"][1][\\\"high\\\"]);print \\\"{**FORMAT**}\\\".format(obj[\\\"Data\\\"][1][\\\"low\\\"]);print obj[\\\"Data\\\"][1][\\\"high\\\"];print obj[\\\"Data\\\"][1][\\\"low\\\"];'\"\rset valueArray to words of value\rset high to item 1 of valueArray\rset low to item 2 of valueArray\rset raw_high to item 3 of valueArray\rset raw_low to item 4 of valueArray",
-            "no-output" : "\rreturn \"**FIATSYMB**\" & high"
+            "response" : "#!\/usr\/bin\/env python\n# -*- coding: utf-8 -*-\nimport urllib2,json,sys\n\ndata = urllib2.urlopen(\"https:\/\/min-api.cryptocompare.com\/data\/histohour?fsym=**CRYPTO**&tsym=**FIAT**&**EXTRAOPTIONS**\")\nobj=json.load(data)\nhigh = \"{}\".format(obj[\"Data\"][1][\"high\"])\nlow = \"{}\".format(obj[\"Data\"][1][\"low\"])\nraw_high = obj[\"Data\"][1][\"high\"]\nraw_low =obj[\"Data\"][1][\"low\"]\n\n",
+            "no-output" : "print(\"**FIATSYMB**\" + high)"
         }
     }
 };

--- a/index.html
+++ b/index.html
@@ -178,7 +178,8 @@
             </form>
 
             <br>
-            <a id="exportJSON" onclick="generateJSON(this);" class="button"><i class="icon-download"></i> export BTT json</a><br>
+            <a id="exportJSON" onclick="outputJson(this);" class="button"><i class="icon-download"></i> download BTT json</a><br>
+            <a id="directExportJSON" onclick="outputDirect(this);" class="button"><i class="icon-download"></i> direct import to BTT</a><br>
 
             <div id="BTTinstructions">
                 <span>The exported json can be imported using the 'import' function, located in the 'Manage Presets' menu which can be found in the bottom left of the BetterTouchTool application. See <a href="https://github.com/chrislennon/Crypto-Touchbar-App#instructions">README</a> for more details.</span>

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -201,8 +201,7 @@ function generateJSON(el) {
         let apiCall = new APIPrice(),
             extraOptions = '';
 
-        let apiReq = apiCall[apiSelector.dataset.apitype].request,
-            apiRes = apiCall[apiSelector.dataset.apitype].response,
+        let apiRes = apiCall[apiSelector.dataset.apitype].response,
             apiOut = apiCall[apiSelector.dataset.apitype][formatSelector.dataset.variance + '-output'];
 
         if (apiSelector.dataset.apitype == 'historical'){
@@ -214,15 +213,11 @@ function generateJSON(el) {
         }
 
 
-        apiReq = apiReq
-            .replace(/\*\*CRYPTO\*\*/g, coin.BTTWidgetName)
-            .replace(/\*\*FIAT\*\*/g, selectedFiatObj.ticker)
-            .replace(/\*\*EXTRAOPTIONS\*\*/g, extraOptions);
-
         apiRes = apiRes
             .replace(/\*\*CRYPTO\*\*/g, coin.BTTWidgetName)
             .replace(/\*\*FIAT\*\*/g, selectedFiatObj.ticker)
-            .replace(/\*\*FORMAT\*\*/g, outputFormat);
+            .replace(/\*\*FORMAT\*\*/g, outputFormat)
+            .replace(/\*\*EXTRAOPTIONS\*\*/g, extraOptions);
         
         apiOut = apiOut
             .replace(/\*\*FIATSYMB\*\*/g, selectedFiatObj.symbol);
@@ -236,7 +231,6 @@ function generateJSON(el) {
 
 
         coin.BTTTriggerConfig.BTTTouchBarAppleScriptString = coin.BTTTriggerConfig.BTTTouchBarAppleScriptString
-            .replace(/\*\*REQUEST\*\*/g, apiReq)
             .replace(/\*\*RESPONSE\*\*/g, apiRes)
             .replace(/\*\*OUTPUT\*\*/g, apiOut);
 

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -127,7 +127,7 @@ function addCrypto(event) {
     }
 }
 
-function generateJSON(el) {
+function generateJSON() {
     const selectedFiatObj = getSelectedFiatValueObject(),
 
         // Get selected cryptos
@@ -259,18 +259,35 @@ function generateJSON(el) {
 
     output.BTTPresetName = output.BTTPresetName + "-" +selectedFiatObj.ticker;
 
-    // trigger download of end result object
-    const data = 'text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(output));
-
-    el.setAttribute('href', 'data:' + data);
-    el.setAttribute('download', 'Crypto-Touchbar-App-' + selectedFiatObj.ticker + '.json');
-
     // Purge all Canvas SVGs after Export
     var myNode = document.getElementById("canvas-area");
     while (myNode.firstChild) {
         myNode.removeChild(myNode.firstChild);
     }
 
+    return output;
+}
+
+function outputJson(el){
+
+    var output = generateJSON(),
+        selectedFiatObj = getSelectedFiatValueObject(); 
+    // trigger download of end result object
+    const data = 'text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(output));
+
+    el.setAttribute('href', 'data:' + data);
+    el.setAttribute('download', 'Crypto-Touchbar-App-' + selectedFiatObj.ticker + '.json');
+}
+
+function outputDirect(el){
+
+    var output = generateJSON(),
+        selectedFiatObj = getSelectedFiatValueObject(); 
+    // trigger import of end result object
+    const data = btoa(unescape(encodeURIComponent(JSON.stringify(output))));
+    console.log(data);
+
+    el.setAttribute('href', 'btt://jsonimport/' + data);
 }
 
 function addCoin(coinData) {


### PR DESCRIPTION
closes #63 
fixes #62 _I think_

Will require alpha version of BTT (2.324) or later.

Implements:
- removal of applescript, replaced with pure python
- POC version of `btt://` import

With this change further work can be conducted to tidy up the internal scripting and bits of code smell - for example shouldn't need multiple variables to handle integers and strings ... _shudders_.

Will merge and deploy with the release of BTT version to stable.

EDIT: Went live with v2.331 of BTT

//CC: @BJJLangedijk, @fifafu