### PR TITLE
Python template refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# ?
+package-lock.json

--- a/templates/crypto_price.py
+++ b/templates/crypto_price.py
@@ -5,8 +5,14 @@
 # https://github.com/chrislennon/Crypto-Touchbar-App/issues 
 
 from json import load
-from urllib2 import urlopen
-from urllib2 import URLError
+try:
+    # Python3
+    from urllib.request import urlopen
+    from urllib.error import URLError
+except ImportError:
+    # Python2
+    from urllib2 import urlopen
+    from urllib2 import URLError
 
 coin_ticker     = "{{coin_ticker}}"    if "{{coin_ticker}}"    else "BTC"
 fiat_ticker     = "{{fiat_ticker}}"    if "{{fiat_ticker}}"    else "USD"
@@ -88,13 +94,13 @@ try:
 
         print(output)
 
-except URLError, e:
+except URLError as url_e:
 
     try:
         with open("/tmp/{0}-{1}-{2}.txt".format(coin_ticker, fiat_ticker, output_type), 'r') as cf:
             print("CACHED " + cf.read())
     except IOError:
-        print("Unable to get data from API & no cache available")
+        print("Unable to get data from API & no cache available\n{0}".format(url_e))
 
-except ValueError, e:
-    print("There was an error formatting the output: {0}".format(e))
+except ValueError as val_e:
+    print("There was an error formatting the output: {0}".format(val_e))

--- a/templates/crypto_price.py
+++ b/templates/crypto_price.py
@@ -48,22 +48,23 @@ try:
         
         output = fiat_symbol + current
 
-        if (output_type is "simple"):
+        if (output_type == "simple"):
             output += trend
-        elif (output_type is "mktcap"):
+        elif (output_type == "mktcap"):
             output += " ({0}{1})".format(fiat_symbol, mktcap)
-        elif (output_type is "absolute"):
+        elif (output_type == "absolute"):
             output += " (L: {0}{1} H: {0}{2})".format(fiat_symbol, low, high)
-        elif (output_type is "relative"):
+        elif (output_type == "relative"):
             output += " (L: -{0}{1} H: +{0}{2})".format(fiat_symbol, str(round(raw_current - raw_low, literalRound)), str(round(raw_high - raw_current,literalRound)))
-        elif (output_type is "current-percentage"):
+        elif (output_type == "current-percentage"):
+            # Display both '-' and '+'? Like +5.7%, 0.0%, -3.3%
             output += " ({0}%)".format(str(round(((raw_current - raw_opening) / raw_current) * 100, percentageRound)))
-        elif (output_type is "range-percentage"):
+        elif (output_type == "range-percentage"):
             output += " (L: -{0}% H: +{1}%)".format(str(round (((raw_current - raw_low) / raw_current) * 100, percentageRound)), str(round (((raw_high - raw_current) / raw_current) * 100, percentageRound)))
-        elif (output_type is "user-percentage"):
+        elif (output_type == "user-percentage"):
             output += " (L: {0}{1} G: {0}{2}".format(fiat_symbol,str(round(raw_current - (raw_current * mod_percent), literalRound)), str(round(raw_current + (raw_current * mod_percent), literalRound)))
 
-        if offline_cache is "true":
+        if offline_cache == "true":
             with open("/tmp/{0}-{1}-{2}.txt".format(coin_ticker, fiat_ticker, output_type), 'w') as cf:
                 cf.write(output)
         
@@ -81,7 +82,7 @@ try:
 
         output = fiat_symbol + high
 
-        if offline_cache is "true":
+        if offline_cache == "true":
             with open("/tmp/{0}-{1}-{2}.txt".format(coin_ticker, fiat_ticker, output_type), 'w') as cf:
                 cf.write(output)
 

--- a/templates/crypto_price.py
+++ b/templates/crypto_price.py
@@ -1,95 +1,97 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-import urllib2,json,sys
 
-coin_ticker = "{{coin_ticker}}" if "{{coin_ticker}}"[0] != "{" else "BTC"
-fiat_ticker = "{{fiat_ticker}}" if "{{fiat_ticker}}"[0] != "{" else "USD"
-fiat_symbol = "{{fiat_symbol}}" if "{{fiat_symbol}}"[0] != "{" else  "$"
-num_format = "{{format}}" if "{{format}}"[2:8] != "format" else  "{}"
-mod_percent = float("{{percent}}") if "{{percent}}"[0] != "{" else float(0)
-output_type = "{{output_type}}" if "{{output_type}}"[0] != "{" else  "mktcap"
-api_type = "{{apiSelector}}" if "{{apiSelector}}"[0] != "{" else  "live"
-extraOptions = "{{{extraOptions}}}" if "{{{extraOptions}}}"[0] != "{" else  "&limit=1&aggregate=1&toTs=1514376000"
-offline_cache = "{{offline_cache}}" if "{{offline_cache}}"[0] != "{" else "false"
+# Please submit any issues to 
+# https://github.com/chrislennon/Crypto-Touchbar-App/issues 
+
+from json import load
+from urllib2 import urlopen
+from urllib2 import URLError
+
+coin_ticker     = "{{coin_ticker}}" if "{{coin_ticker}}"[0] != "{" else "BTC"
+fiat_ticker     = "{{fiat_ticker}}" if "{{fiat_ticker}}"[0] != "{" else "USD"
+fiat_symbol     = "{{fiat_symbol}}" if "{{fiat_symbol}}"[0] != "{" else "$"
+num_format      = "{{format}}" if "{{format}}"[2:8] != "format" else  "{}"
+mod_percent     = float("{{percent}}") if "{{percent}}"[0] != "{" else float(0)
+output_type     = "{{output_type}}" if "{{output_type}}"[0] != "{" else  "mktcap"
+api_type        = "{{apiSelector}}" if "{{apiSelector}}"[0] != "{" else  "live"
+extraOptions    = "{{{extraOptions}}}" if "{{{extraOptions}}}"[0] != "{" else  "&limit=1&aggregate=1&toTs=1514376000"
+offline_cache   = "{{offline_cache}}" if "{{offline_cache}}"[0] != "{" else "false"
 percentageRound = int("{{percentageRound}}") if "{{percentageRound}}"[0] != "{" else int(0)
-literalRound = int("{{literalRound}}") if "{{literalRound}}"[0] != "{" else int(0)
+literalRound    = int("{{literalRound}}") if "{{literalRound}}"[0] != "{" else int(0)
 
 try:
-    if (api_type == "live"):
+    if api_type == "live":
 
-        url = "https://min-api.cryptocompare.com/data/pricemultifull?fsyms={}&tsyms={}".format(coin_ticker, fiat_ticker)
+        URL = "https://min-api.cryptocompare.com/data/pricemultifull?fsyms={0}&tsyms={1}".format(coin_ticker, fiat_ticker)
+        results = load(urlopen(URL))["RAW"][coin_ticker][fiat_ticker]
 
-        data = urllib2.urlopen(url)
-        obj=json.load(data)
-
-        raw_current = float(obj["RAW"][coin_ticker][fiat_ticker]["PRICE"])
-        raw_opening = float(obj["RAW"][coin_ticker][fiat_ticker]["OPEN24HOUR"])
-        raw_high = float(obj["RAW"][coin_ticker][fiat_ticker]["HIGHDAY"])
-        raw_low = float(obj["RAW"][coin_ticker][fiat_ticker]["LOWDAY"])
-        raw_mktcap = float(obj["RAW"][coin_ticker][fiat_ticker]["MKTCAP"])
+        raw_mktcap  = float(results["MKTCAP"])
+        raw_current = float(results["PRICE"])
+        raw_opening = float(results["OPEN24HOUR"])
+        raw_high    = float(results["HIGHDAY"])
+        raw_low     = float(results["LOWDAY"])
+        
         current = num_format.format(raw_current)
         opening = num_format.format(raw_opening)
-        high = num_format.format(raw_high)
-        low = num_format.format(raw_low)
+        high    = num_format.format(raw_high)
+        low     = num_format.format(raw_low)
 
-        if (raw_mktcap > 1000000):
+        if raw_mktcap > 1000000:
             mktcap = str("{:,."+str(literalRound)+"f}").format(raw_mktcap / 1000000) + " M"
         else:
             mktcap = str("{:,."+str(literalRound)+"f}").format(raw_mktcap)
+        
+        trend = "▲" if raw_current > raw_opening else  "▼"
+        
+        output = fiat_symbol + current
 
-        if (raw_current > raw_opening):
-            trend = "▲"
-        else:
-            trend = "▼"
-
-        if (output_type is "no"):
-            output = fiat_symbol + current
-        elif (output_type is "simple"):
-            output = fiat_symbol + current + " " + trend
+        if (output_type is "simple"):
+            output += trend
         elif (output_type is "mktcap"):
-            output = fiat_symbol + current + " (" + fiat_symbol + mktcap + ")"
+            output += " ({0}{1})".format(fiat_symbol, mktcap)
         elif (output_type is "absolute"):
-            output = fiat_symbol + current + " (L: " + fiat_symbol + low + " H: " + fiat_symbol + high + ")"
+            output += " (L: {0}{1} H: {0}{2})".format(fiat_symbol, low, high)
         elif (output_type is "relative"):
-            output = fiat_symbol + current + " (L: -" + fiat_symbol + str(round(raw_current - raw_low, literalRound)) + " H: +" + fiat_symbol + str(round(raw_high - raw_current,literalRound)) + ")"
+            output += " (L: -{0}{1} H: +{0}{2})".format(fiat_symbol, str(round(raw_current - raw_low, literalRound)), str(round(raw_high - raw_current,literalRound)))
         elif (output_type is "current-percentage"):
-            output = fiat_symbol + current + " (" + str(round(((raw_current - raw_opening) / raw_current) * 100, percentageRound)) + "%)"
+            output += " ({0}%)".format(str(round(((raw_current - raw_opening) / raw_current) * 100, percentageRound)))
         elif (output_type is "range-percentage"):
-            output = fiat_symbol + current + " (L: -" + str(round (((raw_current - raw_low) / raw_current) * 100, percentageRound)) + "% H: +" + str(round (((raw_high - raw_current) / raw_current) * 100, percentageRound)) + "%)"
+            output += " (L: -{0}% H: +{1}%)".format(str(round (((raw_current - raw_low) / raw_current) * 100, percentageRound)), str(round (((raw_high - raw_current) / raw_current) * 100, percentageRound)))
         elif (output_type is "user-percentage"):
-            output = fiat_symbol + current + " (L: " + fiat_symbol + str(round(raw_current - (raw_current * mod_percent), literalRound)) + " H: " + fiat_symbol + str(round(raw_current + (raw_current * mod_percent), literalRound)) + ")"
+            output += " (L: {0}{1} G: {0}{2}".format(fiat_symbol,str(round(raw_current - (raw_current * mod_percent), literalRound)), str(round(raw_current + (raw_current * mod_percent), literalRound)))
 
-        if (offline_cache is "true"):
-            tmp_file = open("/tmp/"+coin_ticker+"-"+fiat_ticker+"-"+output_type+".txt", "w")
-            tmp_file.write(output)
-            tmp_file.close()
-
+        if offline_cache is "true":
+            with open("/tmp/{0}-{1}-{2}.txt".format(coin_ticker, fiat_ticker, output_type), 'w') as cf:
+                cf.write(output)
+        
         print(output)
 
-    elif (api_type == "historical"):
+    elif api_type == "historical":
+        
         url = "https://min-api.cryptocompare.com/data/histohour?fsym={}&tsym={}" + extraOptions
         url = url.format(coin_ticker, fiat_ticker)
 
-        data = urllib2.urlopen(url)
-        obj=json.load(data)
+        results = load(urlopen(url))
 
-        raw_high = float(obj["Data"][1]["high"])
+        raw_high = float(results["Data"][1]["high"])
         high = num_format.format(raw_high)
 
         output = fiat_symbol + high
 
-        if (offline_cache is "true"):
-            tmp_file = open("/tmp/"+coin_ticker+"-"+fiat_ticker+"-"+output_type+".txt", "w")
-            tmp_file.write(output)
-            tmp_file.close() 
+        if offline_cache is "true":
+            with open("/tmp/{0}-{1}-{2}.txt".format(coin_ticker, fiat_ticker, output_type), 'w') as cf:
+                cf.write(output)
 
         print(output)
-except urllib2.URLError, e:
+
+except URLError, e:
+
     try:
-        tmp_file = open("/tmp/"+coin_ticker+"-"+fiat_ticker+"-"+output_type+".txt", "r")
-        print 'CACHED ' + tmp_file.read() 
-    except IOError, e:
-        print('Unable to get data from API & no cache available')
+        with open("/tmp/{0}-{1}-{2}.txt".format(coin_ticker, fiat_ticker, output_type), 'r') as cf:
+            print("CACHED " + cf.read())
+    except IOError:
+        print("Unable to get data from API & no cache available")
+
 except ValueError, e:
-    print('There was an error formatting the output: %s' % e)
-# Please submit any issues https://github.com/chrislennon/Crypto-Touchbar-App/issues with the above script
+    print("There was an error formatting the output: {0}".format(e))

--- a/templates/crypto_price.py
+++ b/templates/crypto_price.py
@@ -11,14 +11,14 @@ from urllib2 import URLError
 coin_ticker     = "{{coin_ticker}}" if "{{coin_ticker}}"[0] != "{" else "BTC"
 fiat_ticker     = "{{fiat_ticker}}" if "{{fiat_ticker}}"[0] != "{" else "USD"
 fiat_symbol     = "{{fiat_symbol}}" if "{{fiat_symbol}}"[0] != "{" else "$"
-num_format      = "{{format}}" if "{{format}}"[2:8] != "format" else  "{}"
-mod_percent     = float("{{percent}}") if "{{percent}}"[0] != "{" else float(0)
-output_type     = "{{output_type}}" if "{{output_type}}"[0] != "{" else  "mktcap"
-api_type        = "{{apiSelector}}" if "{{apiSelector}}"[0] != "{" else  "live"
-extraOptions    = "{{{extraOptions}}}" if "{{{extraOptions}}}"[0] != "{" else  "&limit=1&aggregate=1&toTs=1514376000"
+num_format      = "{{format}}" if "{{format}}"[2:8] != "format" else "{}"
+mod_percent     = float("{{percent}}") if "{{percent}}"[0] != "{" else 0.0
+output_type     = "{{output_type}}" if "{{output_type}}"[0] != "{" else "mktcap"
+api_type        = "{{apiSelector}}" if "{{apiSelector}}"[0] != "{" else "live"
+extraOptions    = "{{{extraOptions}}}" if "{{{extraOptions}}}"[0] != "{" else "&limit=1&aggregate=1&toTs=1514376000"
 offline_cache   = "{{offline_cache}}" if "{{offline_cache}}"[0] != "{" else "false"
-percentageRound = int("{{percentageRound}}") if "{{percentageRound}}"[0] != "{" else int(0)
-literalRound    = int("{{literalRound}}") if "{{literalRound}}"[0] != "{" else int(0)
+percentageRound = int("{{percentageRound}}") if "{{percentageRound}}"[0] != "{" else 0
+literalRound    = int("{{literalRound}}") if "{{literalRound}}"[0] != "{" else 0
 
 try:
     if api_type == "live":

--- a/templates/crypto_price.py
+++ b/templates/crypto_price.py
@@ -8,17 +8,31 @@ from json import load
 from urllib2 import urlopen
 from urllib2 import URLError
 
-coin_ticker     = "{{coin_ticker}}" if "{{coin_ticker}}"[0] != "{" else "BTC"
-fiat_ticker     = "{{fiat_ticker}}" if "{{fiat_ticker}}"[0] != "{" else "USD"
-fiat_symbol     = "{{fiat_symbol}}" if "{{fiat_symbol}}"[0] != "{" else "$"
-num_format      = "{{format}}" if "{{format}}"[2:8] != "format" else "{}"
-mod_percent     = float("{{percent}}") if "{{percent}}"[0] != "{" else 0.0
-output_type     = "{{output_type}}" if "{{output_type}}"[0] != "{" else "mktcap"
-api_type        = "{{apiSelector}}" if "{{apiSelector}}"[0] != "{" else "live"
+coin_ticker     = "{{coin_ticker}}"    if "{{coin_ticker}}"[0] != "{"    else "BTC"
+fiat_ticker     = "{{fiat_ticker}}"    if "{{fiat_ticker}}"[0] != "{"    else "USD"
+fiat_symbol     = "{{fiat_symbol}}"    if "{{fiat_symbol}}"[0] != "{"    else "$"
+num_format      = "{{format}}"         if "{{format}}"[2:8] != "format"  else "{}"
+output_type     = "{{output_type}}"    if "{{output_type}}"[0] != "{"    else "mktcap"
+api_type        = "{{apiSelector}}"    if "{{apiSelector}}"[0] != "{"    else "live"
 extraOptions    = "{{{extraOptions}}}" if "{{{extraOptions}}}"[0] != "{" else "&limit=1&aggregate=1&toTs=1514376000"
-offline_cache   = "{{offline_cache}}" if "{{offline_cache}}"[0] != "{" else "false"
-percentageRound = int("{{percentageRound}}") if "{{percentageRound}}"[0] != "{" else 0
+offline_cache   = "{{offline_cache}}"  if "{{offline_cache}}"[0] != "{"  else "false"
+
+# Are these cast really needed?
+mod_percent     = float("{{percent}}") if "{{percent}}"[0] != "{" else 0.0
 literalRound    = int("{{literalRound}}") if "{{literalRound}}"[0] != "{" else 0
+percentageRound = int("{{percentageRound}}") if "{{percentageRound}}"[0] != "{" else 0
+
+coin_ticker = "BTC" if "BTC"[0] != "{" else "BTC"
+fiat_ticker = "EUR" if "EUR"[0] != "{" else "USD"
+fiat_symbol = "€" if "€"[0] != "{" else  "$"
+num_format = "{:0,.2f}" if "{:0,.2f}"[2:8] != "format" else  "{}"
+mod_percent = float("0") if "0"[0] != "{" else float(0)
+output_type = "current-percentage" if "current-percentage"[0] != "{" else  "mktcap"
+api_type = "live" if "live"[0] != "{" else  "live"
+extraOptions = "False" if "False"[0] != "{" else  "&limit=1&aggregate=1&toTs=1514376000"
+offline_cache = "true" if "true"[0] != "{" else "false"
+percentageRound = int("1") if "1"[0] != "{" else int(0)
+literalRound = int("0") if "0"[0] != "{" else int(0)
 
 try:
     if api_type == "live":

--- a/templates/crypto_price.py
+++ b/templates/crypto_price.py
@@ -14,19 +14,18 @@ except ImportError:
     from urllib2 import urlopen
     from urllib2 import URLError
 
-coin_ticker     = "{{coin_ticker}}"    if "{{coin_ticker}}"    else "BTC"
-fiat_ticker     = "{{fiat_ticker}}"    if "{{fiat_ticker}}"    else "USD"
-fiat_symbol     = "{{fiat_symbol}}"    if "{{fiat_symbol}}"    else "$"
 num_format      = "{{format}}"         if "{{format}}"         else "{}"
-output_type     = "{{output_type}}"    if "{{output_type}}"    else "mktcap"
 api_type        = "{{apiSelector}}"    if "{{apiSelector}}"    else "live"
-extraOptions    = "{{{extraOptions}}}" if "{{{extraOptions}}}" else "&limit=1&aggregate=1&toTs=1514376000"
+coin_ticker     = "{{coin_ticker}}"    if "{{coin_ticker}}"    else "BTC"
+fiat_symbol     = "{{fiat_symbol}}"    if "{{fiat_symbol}}"    else "$"
+fiat_ticker     = "{{fiat_ticker}}"    if "{{fiat_ticker}}"    else "USD"
+output_type     = "{{output_type}}"    if "{{output_type}}"    else "mktcap"
 offline_cache   = "{{offline_cache}}"  if "{{offline_cache}}"  else "false"
+extra_options   = "{{{extraOptions}}}" if "{{{extraOptions}}}" else "&limit=1&aggregate=1&toTs=1514376000"
 
-# Are these cast really needed?
-mod_percent     = float("{{percent}}") if "{{percent}}"[0] != "{" else 0.0
-literalRound    = int("{{literalRound}}") if "{{literalRound}}"[0] != "{" else 0
-percentageRound = int("{{percentageRound}}") if "{{percentageRound}}"[0] != "{" else 0
+mod_percent      = float("{{percent}}")        if "{{percent}}"          else 0.0
+literal_round    = int("{{literal_round}}")    if "{{literal_round}}"    else 0
+percentage_round = int("{{percentage_round}}") if "{{percentage_round}}" else 0
 
 try:
     if api_type == "live":
@@ -46,11 +45,11 @@ try:
         low     = num_format.format(raw_low)
 
         if raw_mktcap > 1000000:
-            mktcap = "{0} M".format(round(raw_mktcap / 1000000, literalRound))
+            mktcap = "{0} M".format(round(raw_mktcap / 1000000, literal_round))
         else:
-            mktcap = str(round(raw_mktcap, literalRound))
+            mktcap = str(round(raw_mktcap, literal_round))
 
-        trend = "▲" if raw_current > raw_opening else  "▼"
+        trend = "▲" if raw_current > raw_opening else "▼"
         
         output = fiat_symbol + current
 
@@ -61,14 +60,14 @@ try:
         elif (output_type == "absolute"):
             output += " (L: {0}{1} H: {0}{2})".format(fiat_symbol, low, high)
         elif (output_type == "relative"):
-            output += " (L: -{0}{1} H: +{0}{2})".format(fiat_symbol, str(round(raw_current - raw_low, literalRound)), str(round(raw_high - raw_current,literalRound)))
+            output += " (L: -{0}{1} H: +{0}{2})".format(fiat_symbol, str(round(raw_current - raw_low, literal_round)), str(round(raw_high - raw_current,literal_round)))
         elif (output_type == "current-percentage"):
-            # Display both '-' and '+'? Like +5.7%, 0.0%, -3.3%
-            output += " ({0}%)".format(str(round(((raw_current - raw_opening) / raw_current) * 100, percentageRound)))
+            current_percentage = round(((raw_current - raw_opening) / raw_current) * 100, percentage_round)
+            output += " ({0}{1}%)".format("+" if current_percentage > 0 else "", str(current_percentage))
         elif (output_type == "range-percentage"):
-            output += " (L: -{0}% H: +{1}%)".format(str(round (((raw_current - raw_low) / raw_current) * 100, percentageRound)), str(round (((raw_high - raw_current) / raw_current) * 100, percentageRound)))
+            output += " (L: -{0}% H: +{1}%)".format(str(round (((raw_current - raw_low) / raw_current) * 100, percentage_round)), str(round (((raw_high - raw_current) / raw_current) * 100, percentage_round)))
         elif (output_type == "user-percentage"):
-            output += " (L: {0}{1} G: {0}{2}".format(fiat_symbol,str(round(raw_current - (raw_current * mod_percent), literalRound)), str(round(raw_current + (raw_current * mod_percent), literalRound)))
+            output += " (L: {0}{1} G: {0}{2}".format(fiat_symbol,str(round(raw_current - (raw_current * mod_percent), literal_round)), str(round(raw_current + (raw_current * mod_percent), literal_round)))
 
         if offline_cache == "true":
             with open("/tmp/{0}-{1}-{2}.txt".format(coin_ticker, fiat_ticker, output_type), 'w') as cf:
@@ -78,13 +77,13 @@ try:
 
     elif api_type == "historical":
         
-        url = "https://min-api.cryptocompare.com/data/histohour?fsym={}&tsym={}" + extraOptions
+        url = "https://min-api.cryptocompare.com/data/histohour?fsym={}&tsym={}" + extra_options
         url = url.format(coin_ticker, fiat_ticker)
 
         results = load(urlopen(url))
 
         raw_high = float(results["Data"][1]["high"])
-        high = num_format.format(raw_high)
+        high     = num_format.format(raw_high)
 
         output = fiat_symbol + high
 

--- a/templates/crypto_price.py
+++ b/templates/crypto_price.py
@@ -8,31 +8,19 @@ from json import load
 from urllib2 import urlopen
 from urllib2 import URLError
 
-coin_ticker     = "{{coin_ticker}}"    if "{{coin_ticker}}"[0] != "{"    else "BTC"
-fiat_ticker     = "{{fiat_ticker}}"    if "{{fiat_ticker}}"[0] != "{"    else "USD"
-fiat_symbol     = "{{fiat_symbol}}"    if "{{fiat_symbol}}"[0] != "{"    else "$"
-num_format      = "{{format}}"         if "{{format}}"[2:8] != "format"  else "{}"
-output_type     = "{{output_type}}"    if "{{output_type}}"[0] != "{"    else "mktcap"
-api_type        = "{{apiSelector}}"    if "{{apiSelector}}"[0] != "{"    else "live"
-extraOptions    = "{{{extraOptions}}}" if "{{{extraOptions}}}"[0] != "{" else "&limit=1&aggregate=1&toTs=1514376000"
-offline_cache   = "{{offline_cache}}"  if "{{offline_cache}}"[0] != "{"  else "false"
+coin_ticker     = "{{coin_ticker}}"    if "{{coin_ticker}}"    else "BTC"
+fiat_ticker     = "{{fiat_ticker}}"    if "{{fiat_ticker}}"    else "USD"
+fiat_symbol     = "{{fiat_symbol}}"    if "{{fiat_symbol}}"    else "$"
+num_format      = "{{format}}"         if "{{format}}"         else "{}"
+output_type     = "{{output_type}}"    if "{{output_type}}"    else "mktcap"
+api_type        = "{{apiSelector}}"    if "{{apiSelector}}"    else "live"
+extraOptions    = "{{{extraOptions}}}" if "{{{extraOptions}}}" else "&limit=1&aggregate=1&toTs=1514376000"
+offline_cache   = "{{offline_cache}}"  if "{{offline_cache}}"  else "false"
 
 # Are these cast really needed?
 mod_percent     = float("{{percent}}") if "{{percent}}"[0] != "{" else 0.0
 literalRound    = int("{{literalRound}}") if "{{literalRound}}"[0] != "{" else 0
 percentageRound = int("{{percentageRound}}") if "{{percentageRound}}"[0] != "{" else 0
-
-coin_ticker = "BTC" if "BTC"[0] != "{" else "BTC"
-fiat_ticker = "EUR" if "EUR"[0] != "{" else "USD"
-fiat_symbol = "€" if "€"[0] != "{" else  "$"
-num_format = "{:0,.2f}" if "{:0,.2f}"[2:8] != "format" else  "{}"
-mod_percent = float("0") if "0"[0] != "{" else float(0)
-output_type = "current-percentage" if "current-percentage"[0] != "{" else  "mktcap"
-api_type = "live" if "live"[0] != "{" else  "live"
-extraOptions = "False" if "False"[0] != "{" else  "&limit=1&aggregate=1&toTs=1514376000"
-offline_cache = "true" if "true"[0] != "{" else "false"
-percentageRound = int("1") if "1"[0] != "{" else int(0)
-literalRound = int("0") if "0"[0] != "{" else int(0)
 
 try:
     if api_type == "live":

--- a/templates/crypto_price.py
+++ b/templates/crypto_price.py
@@ -40,10 +40,10 @@ try:
         low     = num_format.format(raw_low)
 
         if raw_mktcap > 1000000:
-            mktcap = str("{:,."+str(literalRound)+"f}").format(raw_mktcap / 1000000) + " M"
+            mktcap = "{0} M".format(round(raw_mktcap / 1000000, literalRound))
         else:
-            mktcap = str("{:,."+str(literalRound)+"f}").format(raw_mktcap)
-        
+            mktcap = str(round(raw_mktcap, literalRound))
+
         trend = "▲" if raw_current > raw_opening else  "▼"
         
         output = fiat_symbol + current


### PR DESCRIPTION
Python script template `crypto_price.py` refactor

- Support for both Python 2 and Python 3
- More readable default parameters
- Used `round` instead of build and eval a format string
- Substitute `is` keyword with `==` operator
- Code cleanup and minor optimizations

Maybe more tests are needed but it seems to work well!
(I have not found a guideline for pr, so I kept all commits made but I could do a squash into something like `chg: python template refactor` if you think it's better)